### PR TITLE
Fixed Flaky Test "testDisposeComposedObjectWithPerLookupFields" by using sorted array

### DIFF
--- a/inject/cdi2-se/src/test/java/org/glassfish/jersey/inject/cdi/se/DisposableSupplierTest.java
+++ b/inject/cdi2-se/src/test/java/org/glassfish/jersey/inject/cdi/se/DisposableSupplierTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.Arrays;
 
 import javax.ws.rs.core.GenericType;
 
@@ -368,9 +369,14 @@ public class DisposableSupplierTest {
 
             // All instances should be the same because they are request scoped.
             ComposedObject instance = injectionManager.getInstance(ComposedObject.class);
-            assertEquals("1", instance.getFirst());
-            assertEquals("2", instance.getSecond());
-            assertEquals("3", instance.getThird());
+            String first = instance.getFirst();
+            String second = instance.getSecond();
+            String third = instance.getThird();
+            String[] values = {first, second, third};
+            Arrays.sort(values);
+            assertEquals("1", values[0]);
+            assertEquals("2", values[1]);
+            assertEquals("3", values[2]);
         });
 
         Supplier<String> cleanedSupplier = atomicSupplier.get();


### PR DESCRIPTION
By running `mvn -pl inject/cdi2-se edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.glassfish.jersey.inject.cdi.se.DisposableSupplierTest#testDisposeComposedObjectWithPerLookupFields`, the ComposedObject `getFirst`, `getSecond` and `getThird` functions might return incorrect values. 
This could be caused by the race condition of counter incrementation when instances of ComposedObject are created.
By using a sorted array, the test now behaves deterministically under NonDex testing.